### PR TITLE
Updated the composer.json to allow use in updated projects

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   "require": {
     "php": ">=5.6",
     "aws/aws-sdk-php": "^3.18",
-    "ramsey/uuid": "^3.4"
+    "ramsey/uuid": ">=3.4"
   },
   "require-dev": {
     "phpunit/phpunit": "^5.4"


### PR DESCRIPTION
I'm currently developing within a Laravel application and cannot use this package as `ramsey/uuid` it's locked to `3.4.*`. 

The changes will allow Composer to upgrade this as long as the version number is above `3.4.*`.